### PR TITLE
Specifying the version for core-ktx library

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     implementation project(path: ':circulartimerview')
-    implementation "androidx.core:core-ktx:1.6.0"
+    implementation "androidx.core:core-ktx:$kotlin_core_ktx"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 repositories {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     implementation project(path: ':circulartimerview')
-    implementation "androidx.core:core-ktx:+"
+    implementation "androidx.core:core-ktx:1.6.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     ext.kotlin_version = '1.3.71'
+    ext.kotlin_core_ktx = '1.6.0'
     repositories {
         google()
         jcenter()

--- a/circulartimerview/build.gradle
+++ b/circulartimerview/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    implementation "androidx.core:core-ktx:1.6.0"
+    implementation "androidx.core:core-ktx:$kotlin_core_ktx"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 repositories {

--- a/circulartimerview/build.gradle
+++ b/circulartimerview/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
-    implementation "androidx.core:core-ktx:+"
+    implementation "androidx.core:core-ktx:1.6.0"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 repositories {


### PR DESCRIPTION
Hi @sureshmaidaragi1919 
core-ktx:+ downloads 1.7.0-alpha02'. A bug has already been raised  here (https://issuetracker.google.com/issues/198469032)
1.7.0 requires compileSdk 31. 
do you mind specifying the version 1.6.0 here in your app. 
once 1.7.0 is stable we can update the core ktx